### PR TITLE
fix: escaped message when use parse mode MarkdownV2 only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,10 @@ jobs:
 #         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      # Breaking Changes
+      # With the update to Node 16, all scripts will now be run with Node 16 rather than Node 12.
+      # https://github.com/actions/upload-artifact/releases/tag/v3.0.0
+      - uses: actions/upload-artifact@v3
 #         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
   parse_mode: 
     description: 'format of message eg: Markdown, MarkdownV2, HTML'
-    default: Markdown
+    default: MarkdownV2
     required: true
 runs:
   using: 'node16'

--- a/src/wrapMessage.js
+++ b/src/wrapMessage.js
@@ -6,7 +6,7 @@ module.exports = async function (message, parse_mode) {
     if(!message) {
         throw new Error('no message found. Exiting')
     }
-    if(parse_mode != "MarkdownV2" || parse_mode != "Markdown") {
+    if(parse_mode != "MarkdownV2") {
         return message
     }
     const escapeMarkdownV2 = (message) => {

--- a/src/wrapMessage.js
+++ b/src/wrapMessage.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-useless-escape */
 // eslint-disable-next-line no-undef
 // https://www.npmjs.com/package/telegramify-markdown
+/* thanks to Nex-Otaku for his gist in
+https://gist.github.com/Nex-Otaku/21b3ff63d7c3040309952d2fe4a27f06 */
 const telegramifyMarkdown = require('telegramify-markdown');
 module.exports = async function (message, parse_mode) {
     if(!message) {

--- a/src/wrapMessage.js
+++ b/src/wrapMessage.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-useless-escape */
 // eslint-disable-next-line no-undef
 // https://www.npmjs.com/package/telegramify-markdown
-/* thanks to Nex-Otaku for his gist in
+/* thanks to Nex-Otaku for his gist
 https://gist.github.com/Nex-Otaku/21b3ff63d7c3040309952d2fe4a27f06 */
 const telegramifyMarkdown = require('telegramify-markdown');
 module.exports = async function (message, parse_mode) {


### PR DESCRIPTION
- fix: escaped message when use parse mode MarkdownV2 only
- fix: uses actions/upload-artifact@v3, all scripts will now be run with Node 16 rather than Node 12